### PR TITLE
add config receiver

### DIFF
--- a/opentelemetry/linux/config.yaml
+++ b/opentelemetry/linux/config.yaml
@@ -1,48 +1,5 @@
 extensions:
   health_check:
-receivers:
-  otlp:  # Define the "otlp" receiver
-    protocols:
-      http:
-        max_request_body_size: 10485760
-
-  filestats:
-    include: /etc/otelcol-contrib/config.yaml
-    collection_interval: 240m
-    initial_delay: 60s
-
-  hostmetrics:
-    collection_interval: 60s
-    scrapers:
-      cpu:
-        metrics:
-          system.cpu.utilization:
-            enabled: true
-      load:
-      memory:
-        metrics:
-          system.memory.utilization:
-            enabled: true
-      disk:
-      filesystem:
-        metrics:
-          system.filesystem.utilization:
-            enabled: true
-      network:
-      paging:
-        metrics:
-          system.paging.utilization:
-            enabled: true
-
-  filelog:
-    include: [/var/log/**/*.log, /var/log/syslog]
-    include_file_path: true
-    retry_on_failure:
-      enabled: true
-    max_log_size: 4MiB
-    operators:
-      - type: filter
-        expr: 'body matches "otel-contrib"'
 
 processors:
   
@@ -104,7 +61,7 @@ service:
       exporters: [logging, otlphttp]
 
     metrics/filestats:
-       receivers: [filestats]
+       receivers: [filestats, filelog/config]
        processors: [resourcedetection, resourcedetection/cloud]
        exporters: [logging, otlphttp]
     
@@ -114,3 +71,54 @@ service:
       exporters: [logging, otlphttp]
 
   extensions: [health_check]
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        max_request_body_size: 10485760
+
+  filestats:
+    include: /etc/otelcol-contrib/config.yaml
+    collection_interval: 240m
+    initial_delay: 60s
+
+  hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      disk:
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      network:
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+
+  filelog:
+    include: [/var/log/**/*.log, /var/log/syslog]
+    include_file_path: true
+    retry_on_failure:
+      enabled: true
+    max_log_size: 4MiB
+    operators:
+      - type: filter
+        expr: 'body matches "otel-contrib"'
+
+  filelog/config:
+    include: [ /etc/otelcol-contrib/config.yaml ]
+    start_at: beginning
+    poll_interval: 5m
+    multiline:
+      line_end_pattern: KEEPTHISASTHELASTLINE


### PR DESCRIPTION
Adds the config as a receiver so we can monitor the config.  This will only add the config when the collector starts and if it changes.